### PR TITLE
Implement models for webhook events

### DIFF
--- a/backend/app/models/event.rb
+++ b/backend/app/models/event.rb
@@ -1,0 +1,5 @@
+class Event < ApplicationRecord
+  belongs_to :webhook_session
+
+  validates :method, :received_at, :ip_address, presence: true
+end

--- a/backend/app/models/webhook_session.rb
+++ b/backend/app/models/webhook_session.rb
@@ -1,0 +1,13 @@
+class WebhookSession < ApplicationRecord
+  has_many :events, dependent: :destroy
+
+  validates :uuid, presence: true, uniqueness: true
+
+  before_validation :assign_uuid, on: :create
+
+  private
+
+  def assign_uuid
+    self.uuid ||= SecureRandom.uuid
+  end
+end

--- a/backend/db/migrate/20250708063501_create_webhook_sessions.rb
+++ b/backend/db/migrate/20250708063501_create_webhook_sessions.rb
@@ -1,0 +1,10 @@
+class CreateWebhookSessions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :webhook_sessions do |t|
+      t.string :uuid, null: false
+
+      t.timestamps
+    end
+    add_index :webhook_sessions, :uuid, unique: true
+  end
+end

--- a/backend/db/migrate/20250708063504_create_events.rb
+++ b/backend/db/migrate/20250708063504_create_events.rb
@@ -1,0 +1,14 @@
+class CreateEvents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :events do |t|
+      t.references :webhook_session, null: false, foreign_key: true
+      t.jsonb :headers, default: {}
+      t.text :body
+      t.string :method, null: false
+      t.datetime :received_at, null: false
+      t.string :ip_address, null: false
+
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add `WebhookSession` and `Event` models
- create migrations for the new tables with constraints

## Testing
- `bin/rails db:create` *(fails: server not running)*
- `bin/rails db:migrate` *(fails: server not running)*

------
https://chatgpt.com/codex/tasks/task_e_686cbb910dfc832c9465373457f82748