### PR TITLE
Implement webhook receiver endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ npm run dev
 
 The app will start on <http://localhost:5173> and will use Axios (to be added) to talk to the Rails API.
 
+### Capturing Webhooks
+
+After starting the Rails server, you can test the webhook receiver by sending a
+POST request to `/webhooks/:uuid` where `:uuid` is any unique identifier. For
+example:
+
+```bash
+curl -X POST http://localhost:3000/webhooks/test-uuid -d '{"ping": true}' \
+  -H 'Content-Type: application/json'
+```
+
+Each request will create a `WebhookSession` (if it does not already exist) and a
+corresponding `Event` record storing the headers and body.
+
 ---
 
 These instructions cover the project setup described in the [PRD](prd_webhook.md) and correspond to **Issue #1** in [ISSUES.md](ISSUES.md).

--- a/backend/app/controllers/webhooks_controller.rb
+++ b/backend/app/controllers/webhooks_controller.rb
@@ -1,0 +1,16 @@
+class WebhooksController < ApplicationController
+  # Receives incoming webhook requests and logs them.
+  def receive
+    session = WebhookSession.find_or_create_by!(uuid: params[:uuid])
+
+    event = session.events.create!(
+      headers: request.headers.to_h,
+      body: request.raw_post,
+      method: request.method,
+      received_at: Time.current,
+      ip_address: request.remote_ip
+    )
+
+    render json: { status: 'received', event_id: event.id }
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
+  post "webhooks/:uuid", to: "webhooks#receive"
+
   # Defines the root path route ("/")
   # root "posts#index"
 end


### PR DESCRIPTION
## Summary
- add WebhooksController with `receive` action
- route POST `/webhooks/:uuid` to the controller
- update README with instructions on sending test webhooks

## Testing
- `bin/rails routes | head -n 20`
- `bin/rails test`

------
https://chatgpt.com/codex/tasks/task_e_686cbe1717dc832cbea06f30b5396eff