### PR TITLE
Implement in-browser webhook sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ curl -X POST http://localhost:3000/events/<event_id>/replay \
   -d "url=http://example.com/target"
 ```
 
+### Sending Test Webhooks from the Browser
+
+The Inspector UI now includes a **Send Test Webhook** form. Enter a session UUID
+and raw JSON payload, then click "Send" to POST the data directly to
+`/webhooks/:uuid`. The response status and body are displayed under the form, and
+the new request will appear in the event list automatically.
+
 ### Managing Sessions
 
 Create a new webhook session (optional `name` parameter for a persistent session):
@@ -91,4 +98,4 @@ curl -X POST http://localhost:3000/sessions
 ---
 
 These instructions cover the project setup described in the [PRD](prd_webhook.md).
-The webhook receiver corresponds to **Issue #1**, while the event listing and replay API correspond to **Issue #4** in [ISSUES.md](ISSUES.md).
+The webhook receiver corresponds to **Issue #1**, the event listing and replay API to **Issue #4**, and the in-browser webhook sender to **Issue #7** in [ISSUES.md](ISSUES.md).

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -51,3 +51,15 @@ header {
   padding: 1rem;
   width: 300px;
 }
+
+.webhook-sender textarea {
+  width: 100%;
+  height: 100px;
+  margin-bottom: 0.5rem;
+}
+
+.webhook-sender pre {
+  white-space: pre-wrap;
+  background: #fafafa;
+  padding: 0.5rem;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,12 +2,14 @@ import { useState } from 'react'
 import EventList, { type EventRecord } from './components/EventList'
 import EventDetail from './components/EventDetail'
 import ReplayModal from './components/ReplayModal'
+import WebhookSender from './components/WebhookSender'
 import './App.css'
 
 function App() {
   const [sessionUuid, setSessionUuid] = useState('')
   const [selected, setSelected] = useState<EventRecord | null>(null)
   const [replayFor, setReplayFor] = useState<EventRecord | null>(null)
+  const [refreshKey, setRefreshKey] = useState(0)
 
   return (
     <div className="app-container">
@@ -19,8 +21,16 @@ function App() {
         />
       </header>
       <div className="panes">
-        <EventList sessionUuid={sessionUuid} onSelect={e => setSelected(e)} />
+        <EventList
+          sessionUuid={sessionUuid}
+          onSelect={e => setSelected(e)}
+          refreshKey={refreshKey}
+        />
         <div className="detail-wrapper">
+          <WebhookSender
+            sessionUuid={sessionUuid}
+            onSent={() => setRefreshKey(r => r + 1)}
+          />
           <EventDetail event={selected} />
           {selected && (
             <button onClick={() => setReplayFor(selected)}>Replay</button>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -12,3 +12,12 @@ export async function replayEvent(eventId: number, url: string) {
   });
   return res.json();
 }
+
+export async function sendTestWebhook(sessionUuid: string, payload: string) {
+  const res = await fetch(`http://localhost:3000/webhooks/${sessionUuid}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: payload,
+  });
+  return { status: res.status, body: await res.text() };
+}

--- a/frontend/src/components/EventList.tsx
+++ b/frontend/src/components/EventList.tsx
@@ -10,9 +10,10 @@ export interface EventRecord {
 interface Props {
   sessionUuid: string
   onSelect: (event: EventRecord) => void
+  refreshKey: number
 }
 
-export default function EventList({ sessionUuid, onSelect }: Props) {
+export default function EventList({ sessionUuid, onSelect, refreshKey }: Props) {
   const [events, setEvents] = useState<EventRecord[]>([])
   const [search, setSearch] = useState('')
 
@@ -21,7 +22,7 @@ export default function EventList({ sessionUuid, onSelect }: Props) {
     fetchEvents(sessionUuid)
       .then(setEvents)
       .catch(err => console.error(err))
-  }, [sessionUuid])
+  }, [sessionUuid, refreshKey])
 
   const filtered = events.filter(e =>
     e.method.toLowerCase().includes(search.toLowerCase()) ||

--- a/frontend/src/components/WebhookSender.tsx
+++ b/frontend/src/components/WebhookSender.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+import { sendTestWebhook } from '../api'
+
+interface Props {
+  sessionUuid: string
+  onSent: () => void
+}
+
+export default function WebhookSender({ sessionUuid, onSent }: Props) {
+  const [payload, setPayload] = useState('{"ping": true}')
+  const [result, setResult] = useState<string | null>(null)
+
+  const handleSend = async () => {
+    const res = await sendTestWebhook(sessionUuid, payload)
+    setResult(`Status: ${res.status}\n${res.body}`)
+    onSent()
+  }
+
+  return (
+    <div className="webhook-sender">
+      <h3>Send Test Webhook</h3>
+      <textarea
+        value={payload}
+        onChange={e => setPayload(e.target.value)}
+      />
+      <button onClick={handleSend} disabled={!sessionUuid}>Send</button>
+      {result && <pre>{result}</pre>}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add WebhookSender component and supporting API call
- refresh event list when new requests are sent
- mention Issue #7 in README with usage instructions

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686cc6dd80ec832cbc3e78bef853287d