### PR TITLE
Add API docs and update references

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,12 @@ expire after **7 days**. Accessing an expired session will return `410 Gone`.
 curl -X POST http://localhost:3000/sessions
 ```
 
+### API Reference
+
+Detailed request and response examples for all endpoints are available in
+[`api-docs.md`](api-docs.md).
+
 ---
 
 These instructions cover the project setup described in the [PRD](prd_webhook.md).
-The webhook receiver corresponds to **Issue #1**, the event listing and replay API to **Issue #4**, and the in-browser webhook sender to **Issue #7** in [ISSUES.md](ISSUES.md).
+The webhook receiver corresponds to **Issue #1**, the event listing and replay API to **Issue #4**, and the in-browser webhook sender to **Issue #7** in [ISSUES.md](ISSUES.md). The API documentation file was added for **Issue #8**.

--- a/api-docs.md
+++ b/api-docs.md
@@ -1,0 +1,80 @@
+# Webhooker API Documentation
+
+This document describes the HTTP endpoints exposed by the Webhooker backend. All endpoints return JSON.
+
+## 1. Create a Session
+
+`POST /sessions`
+
+Create a new webhook session. Optionally provide a `name` parameter for a persistent session.
+
+**Response**
+
+```json
+{ "uuid": "<session_uuid>", "expires_at": "<timestamp>" }
+```
+
+## 2. Receive Webhooks
+
+`POST /webhooks/:uuid`
+
+Log an incoming webhook request for the session identified by `:uuid`.
+
+Example using `curl`:
+
+```bash
+curl -X POST http://localhost:3000/webhooks/test-uuid \
+  -H "Content-Type: application/json" \
+  -d '{"ping": true}'
+```
+
+**Response**
+
+```json
+{ "status": "received", "event_id": 1 }
+```
+
+## 3. List Events
+
+`GET /events/:uuid`
+
+Return all captured events for the given session.
+
+```bash
+curl http://localhost:3000/events/<session_uuid>
+```
+
+**Response**
+
+```json
+[
+  {
+    "id": 1,
+    "headers": { ... },
+    "body": "{\"ping\":true}",
+    "method": "POST",
+    "received_at": "2024-01-01T12:00:00Z"
+  }
+]
+```
+
+## 4. Replay an Event
+
+`POST /events/:id/replay`
+
+Replay a captured request to a different URL by passing the target `url` parameter.
+
+```bash
+curl -X POST http://localhost:3000/events/1/replay \
+  -d "url=http://example.com/target"
+```
+
+**Response**
+
+```json
+{ "status": 200, "body": "OK" }
+```
+
+---
+
+For a quick walkthrough of project setup and UI features see `README.md`. The API endpoints listed here correspond to **Issue #8** in `ISSUES.md`.

--- a/prd_webhook.md
+++ b/prd_webhook.md
@@ -65,6 +65,9 @@ All core features required for a functional webhook management application are i
 
 ## 6. API Endpoints
 
+Detailed request and response examples for these endpoints are provided in
+[`api-docs.md`](api-docs.md).
+
 ### Webhook Receiver
 
 * `POST /webhooks/:uuid`


### PR DESCRIPTION
## Summary
- document API endpoints in new `api-docs.md`
- link README to the new API docs
- mention Issue #8 in README
- reference API docs from the PRD

## Testing
- `npm install` within `frontend`
- `npm run lint` within `frontend`
- `bin/rubocop` within `backend`


------
https://chatgpt.com/codex/tasks/task_e_686cc845e848832cbb19b7e389d4445a