### PR TITLE
Add QA plan and script for issue 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,11 @@ Detailed request and response examples for all endpoints are available in
 
 These instructions cover the project setup described in the [PRD](prd_webhook.md).
 The webhook receiver corresponds to **Issue #1**, the event listing and replay API to **Issue #4**, and the in-browser webhook sender to **Issue #7** in [ISSUES.md](ISSUES.md). The API documentation file was added for **Issue #8**.
+
+### End-to-End Testing
+
+A minimal QA script and manual test plan are provided under the `qa/` folder for **Issue #9**.
+
+1. Start the Rails API server and the React development server.
+2. Run `bash qa/e2e_test.sh` (or follow `qa/manual-test-plan.md`) to create a session, send a test webhook, list events, and replay it to `http://httpbin.org/post`.
+3. Open the Inspector UI at <http://localhost:5173> and verify the test webhook appears and replays successfully.

--- a/qa/e2e_test.sh
+++ b/qa/e2e_test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Simple end-to-end test script for Webhooker
+set -e
+BASE_URL=${BASE_URL:-http://localhost:3000}
+
+# Create session
+SESSION=$(curl -s -X POST $BASE_URL/sessions)
+UUID=$(echo "$SESSION" | jq -r '.uuid')
+if [ -z "$UUID" ] || [ "$UUID" = "null" ]; then
+  echo "Failed to create session" >&2
+  exit 1
+fi
+echo "Created session $UUID"
+
+# Send webhook
+curl -s -X POST $BASE_URL/webhooks/$UUID \
+  -H 'Content-Type: application/json' \
+  -d '{"demo":true}' | jq .
+
+sleep 1
+
+# Fetch events and get first event id
+EVENT_ID=$(curl -s $BASE_URL/events/$UUID | jq -r '.[0].id')
+if [ -z "$EVENT_ID" ] || [ "$EVENT_ID" = "null" ]; then
+  echo "No events found" >&2
+  exit 1
+fi
+echo "Captured event $EVENT_ID"
+
+# Replay the event to httpbin
+curl -s -X POST $BASE_URL/events/$EVENT_ID/replay \
+  -d url=http://httpbin.org/post | jq .
+
+echo "E2E test completed"

--- a/qa/manual-test-plan.md
+++ b/qa/manual-test-plan.md
@@ -1,0 +1,26 @@
+# Manual Test Plan
+
+This document outlines how to verify the complete webhook workflow.
+
+1. **Start services**
+   - From `backend` run `bin/rails server`.
+   - From `frontend` run `npm run dev`.
+2. **Create a session**
+   ```bash
+   curl -X POST http://localhost:3000/sessions
+   ```
+   Save the returned `uuid`.
+3. **Send a test webhook**
+   ```bash
+   curl -X POST http://localhost:3000/webhooks/<uuid> \
+     -H "Content-Type: application/json" \
+     -d '{"hello": "world"}'
+   ```
+4. **Open the Inspector UI**
+   - Visit <http://localhost:5173> and enter the same `uuid`.
+   - The new request should appear in the list.
+5. **Replay the event**
+   - Click "Replay" and use `http://httpbin.org/post` as the target URL.
+   - A `200` response should be displayed.
+6. **Verify**
+   - Ensure the event list updates and no errors are shown.


### PR DESCRIPTION
## Summary
- add `qa` folder with manual test plan and e2e helper script
- document running QA steps in README

## Testing
- `npm run lint` in `frontend`
- `bundle install` and run `bin/rubocop`
- `bin/brakeman -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc967b5a8832c8ff6ce96ba1ef434