### PR TITLE
Fix frontend build

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This demo project shows the initial setup for **Webhooker** using a Rails API ba
 ## Prerequisites
 
 - Ruby 3.4+
-- Node.js 20+
+- Node.js 20+ (use `npm install --legacy-peer-deps` if your Node version is below 22)
 - PostgreSQL
 
 ## Getting Started
@@ -116,11 +116,11 @@ A minimal QA script and manual test plan are provided under the `qa/` folder for
 ### Deployment
 
 The repository includes a `render.yaml` for deploying the app to [Render](https://render.com).
-Build the frontend and copy the generated files into `backend/public`:
+The Docker build now compiles the React app automatically. For local testing you can still build and copy the files manually:
 
 ```bash
 cd frontend
-npm install
+npm install --legacy-peer-deps
 npm run build
 cp -r dist/* ../backend/public/
 ```

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,6 +25,14 @@ ENV RAILS_ENV="production" \
     BUNDLE_PATH="/usr/local/bundle" \
     BUNDLE_WITHOUT="development"
 
+# Build frontend assets
+FROM docker.io/library/node:20 AS frontend-build
+WORKDIR /frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm install --legacy-peer-deps
+COPY frontend/ ./
+RUN npm run build
+
 # Throw-away build stage to reduce size of final image
 FROM base AS build
 
@@ -54,6 +62,7 @@ FROM base
 # Copy built artifacts: gems, application
 COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
 COPY --from=build /rails /rails
+COPY --from=frontend-build /frontend/dist /rails/public
 
 # Run and own only the runtime files as a non-root user for security
 RUN groupadd --system --gid 1000 rails && \


### PR DESCRIPTION
## Summary
- build frontend as part of Docker image
- tweak Docker instructions in README
- mention `npm install --legacy-peer-deps` for Node <22

## Testing
- `npm install --legacy-peer-deps` *(frontend)*
- `npm run build` *(frontend)*
- `bundle install` *(backend)*
- `bundle exec rails db:migrate RAILS_ENV=test` *(fails: server not running)*

------
https://chatgpt.com/codex/tasks/task_e_686ce68a4dd8832c913d441f769606b0